### PR TITLE
harden setup scripts and plugin security

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,14 @@ help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*##"}; {printf "%-20s %s\n", $$1, $$2}'
 
 deps: ## Install prerequisite tools
-	@command -v kubectl >/dev/null || { echo "Installing kubectl"; curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; chmod +x kubectl; mv kubectl /usr/local/bin/; }
-	@command -v kind >/dev/null || { echo "Installing kind"; curl -Lo kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64; chmod +x kind; mv kind /usr/local/bin/; }
-	@command -v kustomize >/dev/null || { echo "Installing kustomize"; curl -Lo kustomize.tar.gz $(curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest | grep -Eo 'https://.+linux_amd64.tar.gz'); tar -xzf kustomize.tar.gz; mv kustomize*/kustomize /usr/local/bin/; chmod +x /usr/local/bin/kustomize; rm -rf kustomize* kustomize.tar.gz; }
+       @BIN_DIR=$${BIN_DIR:-/usr/local/bin}; \
+       if [ ! -w "$$BIN_DIR" ]; then \
+               echo "Cannot write to $$BIN_DIR. Set BIN_DIR or run 'sudo make deps'"; \
+               exit 1; \
+       fi; \
+       command -v kubectl >/dev/null || { echo "Installing kubectl"; curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; chmod +x kubectl; mv kubectl $$BIN_DIR/; }; \
+       command -v kind >/dev/null || { echo "Installing kind"; curl -Lo kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64; chmod +x kind; mv kind $$BIN_DIR/; }; \
+       command -v kustomize >/dev/null || { echo "Installing kustomize"; curl -Lo kustomize.tar.gz $(curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest | grep -Eo 'https://.+linux_amd64.tar.gz'); tar -xzf kustomize.tar.gz; mv kustomize*/kustomize $$BIN_DIR/; chmod +x $$BIN_DIR/kustomize; rm -rf kustomize* kustomize.tar.gz; }
 
 kind-up: ## Create KIND cluster
 	tools/kind/gen-config.sh | kind create cluster --config -

--- a/manifests/nvidia-device-plugin.yaml
+++ b/manifests/nvidia-device-plugin.yaml
@@ -31,6 +31,9 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
           resources:
             requests:
               cpu: 100m

--- a/tools/kind/gen-config.sh
+++ b/tools/kind/gen-config.sh
@@ -4,6 +4,18 @@ set -euo pipefail
 START=${KIND_NODEPORT_START:-30000}
 END=${KIND_NODEPORT_END:-30062}
 
+# Validate nodePort range
+if (( START > END )); then
+  echo "KIND_NODEPORT_START (${START}) must be less than or equal to KIND_NODEPORT_END (${END})" >&2
+  exit 1
+fi
+
+MAX_RANGE=128
+if (( END - START > MAX_RANGE )); then
+  echo "Port range ${START}-${END} exceeds maximum size of ${MAX_RANGE}" >&2
+  exit 1
+fi
+
 cat <<EOF
 # KIND cluster with 1 control plane and 2 workers
 kind: Cluster


### PR DESCRIPTION
## Summary
- add permission check for deps installation path
- validate kind NodePort range
- run NVIDIA device plugin as non-root

## Testing
- `make lint` *(fails: pre-commit: No such file or directory)*
- `tools/kind/gen-config.sh | head`
- `KIND_NODEPORT_START=30010 KIND_NODEPORT_END=30005 tools/kind/gen-config.sh` *(fails: KIND_NODEPORT_START (30010) must be less than or equal to KIND_NODEPORT_END (30005))*
- `KIND_NODEPORT_START=30000 KIND_NODEPORT_END=30550 tools/kind/gen-config.sh` *(fails: Port range 30000-30550 exceeds maximum size of 128)*


------
https://chatgpt.com/codex/tasks/task_e_6897ba603b7883238fca189a42e8e2a3

## Summary by Sourcery

Harden setup scripts and bolster security by validating installation paths and port ranges, and by running the NVIDIA device plugin as a non-root user

Enhancements:
- Check write permission for the dependency installation directory in the Makefile and allow overriding BIN_DIR
- Validate KIND_NODEPORT_START and KIND_NODEPORT_END in the kind config script to ensure start ≤ end and limit the range to 128 ports
- Configure the NVIDIA device plugin manifest to run as non-root (UID/GID 65534) and disable privilege escalation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made the installation directory for prerequisite tools configurable via an environment variable and improved permission checks during setup.
* **Bug Fixes**
  * Added validation to ensure the nodePort range for KIND clusters is within allowed limits and correctly ordered.
* **Refactor**
  * Enhanced the security context of the NVIDIA device plugin to enforce running as a non-root user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->