### PR TITLE
Address review feedback on port range, dependency installation, and device plugin permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ help: ## Show this help
 deps: ## Install prerequisite tools
        @BIN_DIR=$${BIN_DIR:-/usr/local/bin}; \
        if [ ! -w "$$BIN_DIR" ]; then \
-               echo "Cannot write to $$BIN_DIR. Set BIN_DIR or run 'sudo make deps'"; \
+               echo "Cannot write to $$BIN_DIR. Set BIN_DIR to a writable directory, or re-run this command with elevated permissions (e.g., 'sudo make deps')."; \
+               echo "Warning: Running 'sudo make deps' may have unintended side effects. Consider running only the necessary installation commands with elevated permissions."; \
                exit 1; \
        fi; \
        command -v kubectl >/dev/null || { echo "Installing kubectl"; curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; chmod +x kubectl; mv kubectl $$BIN_DIR/; }; \

--- a/manifests/nvidia-device-plugin.yaml
+++ b/manifests/nvidia-device-plugin.yaml
@@ -31,9 +31,9 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-            runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
+            # The device plugin needs access to GPU device files which require root
+            # privileges. If non-root execution is desired, ensure the selected user has
+            # appropriate permissions.
           resources:
             requests:
               cpu: 100m

--- a/tools/kind/gen-config.sh
+++ b/tools/kind/gen-config.sh
@@ -11,7 +11,7 @@ if (( START > END )); then
 fi
 
 MAX_RANGE=128
-if (( END - START > MAX_RANGE )); then
+if (( END - START >= MAX_RANGE )); then
   echo "Port range ${START}-${END} exceeds maximum size of ${MAX_RANGE}" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- include upper bound in KIND nodePort range validation
- clarify BIN_DIR permission message and warn about elevated installs
- adjust NVIDIA device plugin security context to ensure required device access

## Testing
- `bash -n tools/kind/gen-config.sh`
- `pre-commit run --files tools/kind/gen-config.sh Makefile manifests/nvidia-device-plugin.yaml` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6897bbe079c48323a842c79db892d1c9

## Summary by Sourcery

Refine KIND port range validation, clarify dependency installation messaging, and adjust NVIDIA device plugin security context based on review feedback

Bug Fixes:
- Include upper bound in KIND nodePort range validation to enforce the maximum range correctly

Enhancements:
- Improve Makefile deps command to provide clearer permission guidance and warn about elevated installs
- Update NVIDIA device plugin manifest to remove restrictive non-root settings and document root requirements for GPU access